### PR TITLE
Correct typo of "max-age" to "max_age"

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -143,7 +143,7 @@ fn mta_sts(info: HostInfo, stat: &State<ServiceStat>) -> (Status, (ContentType, 
         .map(|mx| format!("mx: {mx}\n"))
         .collect::<Vec<String>>()
         .join("");
-    let content = format!("version: STSv1\nmode: {}\n{}max-age: 86400\n", info.sts_mode, mxs);
+    let content = format!("version: STSv1\nmode: {}\n{}max_age: 86400\n", info.sts_mode, mxs);
 
     stat.mtasts.fetch_add(1, Ordering::Relaxed);
 


### PR DESCRIPTION
As [per RFC 8461](https://www.rfc-editor.org/rfc/rfc8461#page-7), the directive is "max_age".

This resolves #1 